### PR TITLE
Feat/targetting refactor to support projectiles

### DIFF
--- a/Assets/Prefabs.meta
+++ b/Assets/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 08e23076ed0aeea48baf714e9ccce6a5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/PlayerCharacter/PlayerCharacter.prefab
+++ b/Assets/Scenes/PlayerCharacter/PlayerCharacter.prefab
@@ -13,8 +13,8 @@ GameObject:
   - component: {fileID: 5507443561257986778}
   - component: {fileID: 1324519941461058897}
   - component: {fileID: 3768041942426097107}
-  - component: {fileID: 853441205557052961}
   - component: {fileID: 3580988647537165566}
+  - component: {fileID: 1581274357139724008}
   m_Layer: 3
   m_Name: PlayerCharacter
   m_TagString: Player
@@ -81,7 +81,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Sprite: {fileID: -2413806693520163455, guid: ebe73ca9363db456bacf42c025bb4847, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -139,8 +139,35 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9cb0d41af5e37844f8001942a43d5fc3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!61 &853441205557052961
-BoxCollider2D:
+--- !u!50 &3580988647537165566
+Rigidbody2D:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1161942788134814214}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 8
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 1
+  m_Constraints: 4
+--- !u!58 &1581274357139724008
+CircleCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -174,41 +201,4 @@ BoxCollider2D:
   m_CompositeOperation: 0
   m_CompositeOrder: 0
   m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1, y: 1}
-    newSize: {x: 1, y: 1}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
---- !u!50 &3580988647537165566
-Rigidbody2D:
-  serializedVersion: 5
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1161942788134814214}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_GravityScale: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 1
-  m_Constraints: 4
+  m_Radius: 0.5

--- a/Assets/Scenes/PlayerCharacter/Scripts/PlayerCharacter.cs
+++ b/Assets/Scenes/PlayerCharacter/Scripts/PlayerCharacter.cs
@@ -9,6 +9,7 @@ public class PlayerCharacter : Unit
     [SerializeField] private TargetingWidget targetingWidget;
     private PlayerControls playerControls;
     private Equipment equipment;
+    private Collider2D playerCollider;
     private float heat;
 
     public static PlayerCharacter Instance { get; private set; }
@@ -29,6 +30,7 @@ public class PlayerCharacter : Unit
 
         equipment = GetComponent<Equipment>();
         playerControls = GetComponent<PlayerControls>();
+        playerCollider = GetComponent<Collider2D>();
     }
 
     private void Start()
@@ -72,18 +74,56 @@ public class PlayerCharacter : Unit
 
     private void HandleMove(Vector2 movementInput)
     {
-        gameObject.transform.Translate(movementInput * MovementSpeed * Time.deltaTime);
-        if (movementInput != Vector2.zero)
-        {
-            float movementMagnitude = movementInput.magnitude * MovementSpeed * Time.deltaTime;
-            ItemTriggerEventSystem.Instance.SendTriggerEvent(ETriggerType.OnMove, new ItemTriggerEventContext(targettedPosition: targetingWidget.transform.position, changeValue: movementMagnitude));
-        }
-    }
+        Vector2 movementInput2D = new(movementInput.x, movementInput.y);
+        float movementMagnitude = movementInput2D.magnitude * MovementSpeed * Time.deltaTime;
 
+        if (movementInput2D == Vector2.zero)
+            return;
+
+        movementInput2D = correctMovementINputForCollisions(movementInput2D, movementMagnitude);
+
+        gameObject.transform.Translate(movementInput2D.normalized * movementMagnitude);
+        ItemTriggerEventSystem.Instance.SendTriggerEvent(
+            ETriggerType.OnMove,
+            new ItemTriggerEventContext(targettedPosition: targetingWidget.transform.position, changeValue: movementMagnitude)
+        );
+    }
     private void HandleUseItem(ESlotsInEquipment itemSlot, EItemUsageType usageType)
     {
         Vector3 targettedPosition = targetingWidget.transform.position;
         equipment.UseItem(itemSlot, usageType, targettedPosition);
+    }
+
+    private Vector2 correctMovementINputForCollisions(Vector2 movementInput2D, float movementMagnitude)
+    {
+        float radius = playerCollider.bounds.extents.x;
+        float castDistance = movementMagnitude * 1.2f; // slight buffer added to ensure collision is detected
+
+        RaycastHit2D hit = Physics2D.CircleCast(
+            transform.position,
+            radius,
+            movementInput2D.normalized,
+            castDistance,
+            LayerMask.GetMask(new string[] { "Environment" })
+        );
+
+        Debug.DrawRay(transform.position, movementInput2D.normalized * (radius + castDistance), Color.red);
+
+        if (hit.collider != null)
+        {
+            Debug.DrawRay(hit.point, hit.normal, Color.blue);
+
+            float dot = Vector2.Dot(movementInput2D.normalized, hit.normal);
+            if (dot < 0)
+            {
+                Vector2 slideDirection = (movementInput2D.normalized - dot * hit.normal).normalized;
+                movementInput2D = slideDirection * movementInput2D.magnitude;
+
+                Debug.DrawRay(transform.position, slideDirection * movementMagnitude, Color.green);
+            }
+        }
+
+        return movementInput2D;
     }
 
     private void EquipDebugItem()

--- a/Assets/Scenes/PlayerCharacter/Scripts/PlayerCharacter.cs
+++ b/Assets/Scenes/PlayerCharacter/Scripts/PlayerCharacter.cs
@@ -80,7 +80,7 @@ public class PlayerCharacter : Unit
         if (movementInput2D == Vector2.zero)
             return;
 
-        movementInput2D = correctMovementINputForCollisions(movementInput2D, movementMagnitude);
+        movementInput2D = CorrectMovementINputForCollisions(movementInput2D, movementMagnitude);
 
         gameObject.transform.Translate(movementInput2D.normalized * movementMagnitude);
         ItemTriggerEventSystem.Instance.SendTriggerEvent(
@@ -94,7 +94,7 @@ public class PlayerCharacter : Unit
         equipment.UseItem(itemSlot, usageType, targettedPosition);
     }
 
-    private Vector2 correctMovementINputForCollisions(Vector2 movementInput2D, float movementMagnitude)
+    private Vector2 CorrectMovementINputForCollisions(Vector2 movementInput2D, float movementMagnitude)
     {
         float radius = playerCollider.bounds.extents.x;
         float castDistance = movementMagnitude * 1.2f; // slight buffer added to ensure collision is detected

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -390,6 +390,7 @@ GameObject:
   - component: {fileID: 519420031}
   - component: {fileID: 519420029}
   - component: {fileID: 519420030}
+  - component: {fileID: 519420033}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -508,13 +509,28 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 519420028}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &519420033
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519420028}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4abd2c04c2a14304ebd6bf8c8667c490, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  movementSpeed: 0
+  target: {fileID: 1645878592}
+  matchTargetSpeed: 1
 --- !u!1001 &520155908
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -981,6 +997,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 2557189946190320129, guid: b27f5645c9d56c045baa6a11bd643572, type: 3}
   m_PrefabInstance: {fileID: 143236472}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1645878592 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5507443561257986778, guid: 361d10a0deebc8c41ad235675847f716, type: 3}
+  m_PrefabInstance: {fileID: 1662552900}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 34d8b0df952510f48ad67ea9d4f010b7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1662552900
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -119,6 +119,168 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &96082274
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 96082278}
+  - component: {fileID: 96082277}
+  - component: {fileID: 96082276}
+  - component: {fileID: 96082275}
+  m_Layer: 6
+  m_Name: Static Sprite
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!50 &96082275
+Rigidbody2D:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 96082274}
+  m_BodyType: 2
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!61 &96082276
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 96082274}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!212 &96082277
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 96082274}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &96082278
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 96082274}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: 0.3620647, w: 0.932153}
+  m_LocalPosition: {x: 5.01, y: -2.29, z: 0}
+  m_LocalScale: {x: 6.058, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 42.454}
 --- !u!1001 &143236472
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -450,6 +612,168 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 545d9258c4cddbf4db4e67490abfaca8, type: 3}
+--- !u!1 &596988648
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 596988652}
+  - component: {fileID: 596988651}
+  - component: {fileID: 596988650}
+  - component: {fileID: 596988649}
+  m_Layer: 6
+  m_Name: Static Sprite (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!50 &596988649
+Rigidbody2D:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 596988648}
+  m_BodyType: 2
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!61 &596988650
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 596988648}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!212 &596988651
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 596988648}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &596988652
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 596988648}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.05, y: -4.23, z: 0}
+  m_LocalScale: {x: 6.058, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &619394800
 GameObject:
   m_ObjectHideFlags: 0
@@ -721,6 +1045,10 @@ PrefabInstance:
       propertyPath: m_TagString
       value: Player
       objectReference: {fileID: 0}
+    - target: {fileID: 3580988647537165566, guid: 361d10a0deebc8c41ad235675847f716, type: 3}
+      propertyPath: m_ExcludeLayers.m_Bits
+      value: 8
+      objectReference: {fileID: 0}
     - target: {fileID: 5507443561257986778, guid: 361d10a0deebc8c41ad235675847f716, type: 3}
       propertyPath: targetingWidget
       value: 
@@ -865,6 +1193,159 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   itemsDataPath: Systems/ItemsSystem/ItemData
+--- !u!1 &2030271242
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2030271246}
+  - component: {fileID: 2030271245}
+  - component: {fileID: 2030271244}
+  - component: {fileID: 2030271243}
+  m_Layer: 6
+  m_Name: Static Sprite (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!50 &2030271243
+Rigidbody2D:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2030271242}
+  m_BodyType: 2
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!70 &2030271244
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2030271242}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 1, y: 2}
+  m_Direction: 0
+--- !u!212 &2030271245
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2030271242}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -9095717837082945937, guid: 34587324d412940a79d530020c957dc0, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &2030271246
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2030271242}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: 0.29160604, w: 0.9565385}
+  m_LocalPosition: {x: -5.8866, y: -1.385, z: 0}
+  m_LocalScale: {x: 1.4399, y: 1.50332, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 33.908}
 --- !u!1001 &2118516913
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1020,7 +1501,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7012843419100885857, guid: 6b9fde8fa92a029499053579332c5897, type: 3}
       propertyPath: m_IsTrigger
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -1133,3 +1614,6 @@ SceneRoots:
   - {fileID: 736432140}
   - {fileID: 2017922248}
   - {fileID: 1228674177}
+  - {fileID: 96082278}
+  - {fileID: 596988652}
+  - {fileID: 2030271246}

--- a/Assets/Systems/Camera.meta
+++ b/Assets/Systems/Camera.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 231aa1733212a1546b78750fefa884e5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Systems/Camera/FollowingCamera.cs
+++ b/Assets/Systems/Camera/FollowingCamera.cs
@@ -1,0 +1,67 @@
+using System.Text.RegularExpressions;
+using UnityEngine;
+
+public class FollowingCamera : MonoBehaviour
+{
+    [SerializeField] private float movementSpeed = 5f;
+    [SerializeField] private MonoBehaviour target;
+    [SerializeField] private bool matchTargetSpeed;
+    private float defaultMovementSpeed;
+    private bool isStopped = false;
+
+    private void Start()
+    {
+        if (matchTargetSpeed)
+        {
+            MatchMovementSpeedToTarget();
+        }
+
+        defaultMovementSpeed = movementSpeed;
+    }
+
+    private void Update()
+    {
+        if (isStopped)
+            return;
+
+        if (target != null)
+        {
+            if (matchTargetSpeed)
+            {
+                MatchMovementSpeedToTarget();
+            }
+
+            Vector3 targetPosition = target.transform.position;
+            targetPosition.z = transform.position.z;
+            transform.position = Vector3.Lerp(transform.position, targetPosition, movementSpeed * Time.deltaTime);
+        }
+        else
+        {
+            Debug.LogWarning("FollowingCamera has no target assigned.");
+        }
+    }
+
+    public void Stop()
+    {
+        isStopped = true;
+        movementSpeed = 0f;
+    }
+
+    public void Resume()
+    {
+        isStopped = false;
+        movementSpeed = defaultMovementSpeed;
+    }
+
+    private void MatchMovementSpeedToTarget()
+    {
+        if (target is Unit unit)
+        {
+            movementSpeed = unit.MovementSpeed;
+        }
+        else
+        {
+            Debug.LogWarning("FollowingCamera target does not have a Unit component to match movement speed.");
+        }
+    }
+}

--- a/Assets/Systems/Camera/FollowingCamera.cs.meta
+++ b/Assets/Systems/Camera/FollowingCamera.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4abd2c04c2a14304ebd6bf8c8667c490

--- a/Assets/Systems/ItemsSystem/ItemData/debug_item.json
+++ b/Assets/Systems/ItemsSystem/ItemData/debug_item.json
@@ -22,6 +22,24 @@
     },
     {
       "EffectIds": [
+        "deal_damage"
+      ],
+      "TriggerType": 1,
+      "Cooldown": 3.0,
+      "TargetingMode": {
+        "TargetingType": 3,
+        "Range": 5.0,
+        "TravelTime": 1.0,
+        "AllowMultipleTargets": false
+      },
+      "EffectParams": [
+        {
+          "Value": 0.5
+        }
+      ]
+    },
+    {
+      "EffectIds": [
         "deal_damage",
         "damage_over_time"
       ],

--- a/Assets/Systems/ItemsSystem/TypeDefinitions/DataTypes/TargetingModeData.cs
+++ b/Assets/Systems/ItemsSystem/TypeDefinitions/DataTypes/TargetingModeData.cs
@@ -5,6 +5,7 @@ public struct TargetingModeData
 {
   public ETargetingType TargetingType;
   public float Range;
+  public float TravelTime;
   public bool AllowMultipleTargets;
   public bool TargetCaster;
 }

--- a/Assets/Systems/ItemsSystem/TypeDefinitions/Item.cs
+++ b/Assets/Systems/ItemsSystem/TypeDefinitions/Item.cs
@@ -82,15 +82,7 @@ public class Item
 
         TargetingMode targetingMode = itemEffects.TargetingMode;
         TargetingStrategy strategy = TargetingStrategyUtils.GetTargetingStrategy(targetingMode.TargetingType);
-        Unit[] targets = strategy.Target(targetingMode, targettedPosition, PlayerCharacter.Instance);
-
-        foreach (var target in targets)
-        {
-          foreach (var effect in itemEffects.Effects)
-          {
-            effect.ApplyEffect(PlayerCharacter.Instance, target);
-          }
-        }
+        strategy.Target(targetingMode, targettedPosition, PlayerCharacter.Instance, itemEffects.Effects);
       }
     }
   }

--- a/Assets/Systems/ItemsSystem/TypeDefinitions/TargetingMode.cs
+++ b/Assets/Systems/ItemsSystem/TypeDefinitions/TargetingMode.cs
@@ -2,18 +2,21 @@ public class TargetingMode
 {
   public ETargetingType TargetingType { get { return targetingType; } }
   public float Range { get { return range; } }
+  public float TravelTime { get { return travelTime; } }
   public bool AllowMultipleTargets { get { return allowMultipleTargets; } }
   public bool TargetCaster { get { return targetCaster; } }
 
   private ETargetingType targetingType;
   private float range;
+  private float travelTime;
   private bool allowMultipleTargets;
   private bool targetCaster;
 
-  public TargetingMode(ETargetingType _targetingType, float _range, bool _allowMultipleTargets, bool _targetCaster)
+  public TargetingMode(ETargetingType _targetingType, float _range, float _travelTime = 0.1f, bool _allowMultipleTargets = false, bool _targetCaster = false)
   {
     targetingType = _targetingType;
     range = _range;
+    travelTime = _travelTime;
     allowMultipleTargets = _allowMultipleTargets;
     targetCaster = _targetCaster;
   }
@@ -22,6 +25,7 @@ public class TargetingMode
   {
     targetingType = data.TargetingType;
     range = data.Range;
+    travelTime = data.TravelTime;
     allowMultipleTargets = data.AllowMultipleTargets;
     targetCaster = data.TargetCaster;
   }

--- a/Assets/Systems/Targeting/TargetingStrategy.cs
+++ b/Assets/Systems/Targeting/TargetingStrategy.cs
@@ -2,5 +2,13 @@ using UnityEngine;
 
 abstract public class TargetingStrategy
 {
-  public abstract Unit[] Target(TargetingMode targetingMode, Vector3 target, Unit caster);
+  public abstract void Target(TargetingMode targetingMode, Vector3 target, Unit caster, Effect[] effects);
+
+  protected void ApplyEffectsToUnit(Unit target, Unit caster, Effect[] effects)
+  {
+    foreach (var effect in effects)
+    {
+      effect.ApplyEffect(caster, target);
+    }
+  }
 }

--- a/Assets/Systems/Targeting/TargetingStrategyUtils.cs
+++ b/Assets/Systems/Targeting/TargetingStrategyUtils.cs
@@ -7,7 +7,7 @@ public class TargetingStrategyUtils
     { ETargetingType.Self, new SelfTargetingStrategy() },
     { ETargetingType.Line, new LineTargetingStrategy() },
     { ETargetingType.Area, new AreaTargetingStrategy() },
-    // { ETargetingType.Projectile, new ProjectileTargetingStrategy() },
+    { ETargetingType.Projectile, new ProjectileTargetingStrategy() },
     { ETargetingType.Point, new PointTargetingStrategy() },
   };
 

--- a/Assets/Systems/Targeting/TargettingStrategies/AreaTargetingStrategy.cs
+++ b/Assets/Systems/Targeting/TargettingStrategies/AreaTargetingStrategy.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 public class AreaTargetingStrategy : TargetingStrategy
 {
-  public override Unit[] Target(TargetingMode targetingMode, Vector3 target, Unit caster)
+  public override void Target(TargetingMode targetingMode, Vector3 target, Unit caster, Effect[] effects)
   {
     Vector3 origin = caster.transform.position;
     Collider2D[] hitColliders = Physics2D.OverlapCircleAll(target, targetingMode.Range);
@@ -26,7 +26,11 @@ public class AreaTargetingStrategy : TargetingStrategy
         targets.Add(unit);
       }
     }
-    return targets.ToArray();
+
+    foreach (var targetUnit in targets)
+    {
+      ApplyEffectsToUnit(targetUnit, caster, effects);
+    }
   }
 
   private void DrawDebugCircle(Vector3 center, float radius, Color color, float duration)

--- a/Assets/Systems/Targeting/TargettingStrategies/LineTargetingStrategy.cs
+++ b/Assets/Systems/Targeting/TargettingStrategies/LineTargetingStrategy.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 
 public class LineTargetingStrategy : TargetingStrategy
 {
-  public override Unit[] Target(TargetingMode targetingMode, Vector3 target, Unit caster)
+  public override void Target(TargetingMode targetingMode, Vector3 target, Unit caster, Effect[] effects)
   {
     Vector3 origin = caster.transform.position;
     var direction = (target - origin).normalized;
-    RaycastHit2D[] hits = hits = Physics2D.RaycastAll(origin, direction, targetingMode.Range); ;
+    RaycastHit2D[] hits = Physics2D.RaycastAll(origin, direction, targetingMode.Range);
 
     // draw debug line
     Debug.DrawLine(origin, origin + direction * targetingMode.Range, Color.red, 1f);
@@ -27,6 +27,10 @@ public class LineTargetingStrategy : TargetingStrategy
         units.Add(unit);
       }
     }
-    return units.ToArray();
+
+    foreach (var targetUnit in units)
+    {
+      ApplyEffectsToUnit(targetUnit, caster, effects);
+    }
   }
 }

--- a/Assets/Systems/Targeting/TargettingStrategies/PointTargetingStrategy.cs
+++ b/Assets/Systems/Targeting/TargettingStrategies/PointTargetingStrategy.cs
@@ -2,14 +2,16 @@ using UnityEngine;
 
 public class PointTargetingStrategy : AreaTargetingStrategy
 {
-    public override Unit[] Target(TargetingMode targetingMode, Vector3 target, Unit caster)
+    public override void Target(TargetingMode targetingMode, Vector3 target, Unit caster, Effect[] effects)
     {
         TargetingMode rangeAdjustedPointTargetingMode = new TargetingMode(
             targetingMode.TargetingType,
             targetingMode.Range > 0 ? targetingMode.Range : 0.1f,
+            targetingMode.TravelTime > 0.0f ? targetingMode.TravelTime : 0.1f,
             targetingMode.TargetCaster,
             targetingMode.AllowMultipleTargets
         );
-        return base.Target(rangeAdjustedPointTargetingMode, target, caster);
+
+        base.Target(rangeAdjustedPointTargetingMode, target, caster, effects);
     }
 }

--- a/Assets/Systems/Targeting/TargettingStrategies/ProjectileTargetingStrategy.cs
+++ b/Assets/Systems/Targeting/TargettingStrategies/ProjectileTargetingStrategy.cs
@@ -1,0 +1,56 @@
+using UnityEngine;
+
+public class ProjectileTargetingStrategy : TargetingStrategy
+{
+  public override void Target(TargetingMode targetingMode, Vector3 target, Unit caster, Effect[] effects)
+  {
+    Vector3 origin = caster.transform.position;
+    var direction = (target - origin).normalized;
+    Vector3 destination = origin + direction * targetingMode.Range;
+
+    // starts a coroutine to move the projectile on a caster
+    // this is a unity way to handle async operations without blocking the main thread
+    caster.StartCoroutine(CastProjectile(origin, destination, targetingMode.TravelTime, caster, effects, targetingMode.AllowMultipleTargets));
+  }
+
+  private System.Collections.IEnumerator CastProjectile(Vector3 from, Vector3 to, float travelTime, Unit caster, Effect[] effects, bool targetMultiple)
+  {
+    float elapsedTime = 0f;
+    Vector3 previousPosition = from;
+    bool wasUnitHit = false;
+
+    while (elapsedTime <= travelTime && (!wasUnitHit || targetMultiple))
+    {
+      float t = elapsedTime / travelTime;
+      Vector3 currentPosition = Vector3.Lerp(from, to, t);
+
+      // draw debug line
+      Debug.DrawLine(previousPosition, currentPosition, Color.green, 0.2f);
+
+      RaycastHit2D[] hits = Physics2D.RaycastAll(previousPosition, (to - from).normalized, (currentPosition - previousPosition).magnitude);
+      foreach (var hit in hits)
+      {
+        Unit unit = hit.collider.GetComponent<Unit>();
+        if (unit != null)
+        {
+          if (unit == caster)
+            continue;
+
+          ApplyEffectsToUnit(unit, caster, effects);
+          wasUnitHit = true;
+
+          if (!targetMultiple)
+          {
+            break;
+          }
+        }
+      }
+
+      previousPosition = currentPosition;
+
+      // this awaits for the next frame, without adding additional artificial delay
+      yield return null;
+      elapsedTime += Time.deltaTime;
+    }
+  }
+}

--- a/Assets/Systems/Targeting/TargettingStrategies/ProjectileTargetingStrategy.cs.meta
+++ b/Assets/Systems/Targeting/TargettingStrategies/ProjectileTargetingStrategy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2ef6163ef9d901644be33bd843d2ccfe

--- a/Assets/Systems/Targeting/TargettingStrategies/SelfTargetingStrategy.cs
+++ b/Assets/Systems/Targeting/TargettingStrategies/SelfTargetingStrategy.cs
@@ -2,8 +2,8 @@ using UnityEngine;
 
 public class SelfTargetingStrategy : AreaTargetingStrategy
 {
-  public override Unit[] Target(TargetingMode targetingMode, Vector3 target, Unit caster)
+  public override void Target(TargetingMode targetingMode, Vector3 target, Unit caster, Effect[] effects)
   {
-    return base.Target(targetingMode, caster.transform.position, caster);
+    base.Target(targetingMode, caster.transform.position, caster, effects);
   }
 }


### PR DESCRIPTION
refactored `TargetingStrategy` to support async casting
ProjectileTargetingStrategy added - this sends a travelling beam, that will interact with colliders it meats during the travel

Added player character collision fixes, to correctly and smoothly stop at barriers and slide alongside them